### PR TITLE
Move non-reusable functions

### DIFF
--- a/SwiftExtensions/OperationQueueExtensions.swift
+++ b/SwiftExtensions/OperationQueueExtensions.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 
+public struct OperationQueueContext {
+    public let queue: OperationQueue
+    public let dispatchQueue: DispatchQueue
+}
+
 public extension OperationQueue {
     static let senteraUtilityQueue = DispatchQueue(label: "senteraUtilityQueue", qos: .utility)
     static func serialQueue(with name: String, qos: DispatchQoS.QoSClass = .default) -> OperationQueue {
@@ -22,5 +27,17 @@ public extension OperationQueue {
         }
         queue.name = "\(name)_OperationQueue"
         return queue
+    }
+
+    static func serialQueueContext(with name: String, qos: DispatchQoS = .default) -> OperationQueueContext {
+        let queue = OperationQueue()
+        queue.name = "\(name)_OperationQueue"
+        queue.maxConcurrentOperationCount = 1
+        queue.qualityOfService = .default
+
+        let dispatchQueue = DispatchQueue(label: name, qos: qos)
+        queue.underlyingQueue = dispatchQueue
+
+        return OperationQueueContext(queue: queue, dispatchQueue: dispatchQueue)
     }
 }

--- a/SwiftExtensions/UIDeviceExtensions.swift
+++ b/SwiftExtensions/UIDeviceExtensions.swift
@@ -32,7 +32,7 @@ public extension UIDevice {
             return identifier + String(UnicodeScalar(UInt8(value)))
         }
 
-        func mapToDevice(identifier: String) -> String { // swiftlint:disable:this cyclomatic_complexity
+        func mapToDevice(identifier: String) -> String {
             #if os(iOS)
             switch identifier {
             case "iPod5,1":                                 return "iPod touch (5th generation)"


### PR DESCRIPTION
Several Sentera specific date formatters were included in `DateFormatter` extensions. These have been moved out of SwiftExtensions.